### PR TITLE
Prevent empty heaver toggler

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,22 +5,25 @@
                 {{ .Site.Title }}
             </a>
         </div>
-        <button class="navbar-toggler navbar-toggler-right collapsed" type="button" data-toggle="collapse" data-target="#navbarMainCollapse" aria-controls="navbarMainCollapse" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
+        <!-- only add the navbar toggle button if there are elements within the toggle -->
+        {{- if .Site.Menus.shortcuts}}
+            <button class="navbar-toggler navbar-toggler-right collapsed" type="button" data-toggle="collapse" data-target="#navbarMainCollapse" aria-controls="navbarMainCollapse" aria-expanded="false" aria-label="Toggle navigation">
+              <span class="navbar-toggler-icon"></span>
+            </button>
 
-        <div class="collapse navbar-collapse" id="navbarMainCollapse">
-          <ul class="navbar-nav ml-auto">
-              {{- with .Site.Menus.shortcuts}}
-                    {{- range sort . "Weight"}}
-                        <li class="nav-item">
-                            <a class="nav-link" href="{{.URL}}" {{if eq $.Site.Params.menushortcutsnewtab true}}target="_blank"{{end}}>
-                              {{safeHTML .Name}}
-                            </a>
-                        </li>
-                    {{- end}}
-              {{- end}}
-          </ul>
-        </div>
+            <div class="collapse navbar-collapse" id="navbarMainCollapse">
+              <ul class="navbar-nav ml-auto">
+                  {{- with .Site.Menus.shortcuts}}
+                        {{- range sort . "Weight"}}
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{.URL}}" {{if eq $.Site.Params.menushortcutsnewtab true}}target="_blank"{{end}}>
+                                  {{safeHTML .Name}}
+                                </a>
+                            </li>
+                        {{- end}}
+                  {{- end}}
+              </ul>
+            </div>
+        {{ - end}}
     </div>
 </nav>


### PR DESCRIPTION
prevent the header's navbar toggle appearing if there are not elements to display (thus no toggle needed)