### PR TITLE
Fix minifier error with spacing in next-prev-page

### DIFF
--- a/layouts/partials/next-prev-page.html
+++ b/layouts/partials/next-prev-page.html
@@ -38,10 +38,10 @@
     <div class="d-flex justify-content-center">
         {{- if not $.Site.Params.disableNavChevron -}}
             {{- with ($.Scratch.Get "prevPage") -}}
-                <a class="p-1 mr-3 d-inline-block text-white" href="{{.RelPermalink}}" title="{{.Title}}"> <i class="fas fa-chevron-left"></i> {{.Title}}</a>
+                <a class="p-1 mr-3 d-inline-block text-white" href="{{.RelPermalink}}" title="{{.Title}}"><i class="fas fa-chevron-left p-1"></i>{{.Title}}</a>
             {{ end -}}
             {{- with ($.Scratch.Get "nextPage") -}}
-                <a class="p-1 ml-3 d-inline-block text-white text-right" href="{{.RelPermalink}}" title="{{.Title}}">{{.Title}} <i class="fas fa-chevron-right"></i></a>
+                <a class="p-1 ml-3 d-inline-block text-white text-right" href="{{.RelPermalink}}" title="{{.Title}}">{{.Title}}<i class="fas fa-chevron-right p-1"></i></a>
             {{- end }}
         {{- end -}}
     </div>


### PR DESCRIPTION
when using `--minify` with hugo, the space characters used for padding are removed. Adding a p-1 class to the chevrons is sufficient to fix this.