### PR TITLE
Allow Google Analytics to only track production site

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,6 +17,9 @@
     {{ $style := resources.Get "css/ace.scss" | toCSS | minify }}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
 
-    {{ template "_internal/google_analytics_async.html" . }}
+    <!-- Only include the tracking when using `hugo` or adding `--environment production` -->
+    {{ if eq hugo.Environment "production" }}
+        {{ template "_internal/google_analytics_async.html" . }}
+    {{ end }}
 
 </head>


### PR DESCRIPTION
prevents loading the google analytics internal partial unless the system is in "production" mode

`hugo` defaults to "production". `hugo server` defaults to "development".
* Any command can add `--environment production` to the hugo command
* OR add HUGO_ENVIRONMENT="production" to the shell running hugo

a config param could also be introduced to always add the template
(`if or .Site.Params.alwaysAnalytics (eq hugo.Environment "production")`)

*[inspiration](https://discourse.gohugo.io/t/how-to-exclude-google-analytics-when-running-under-hugo-local-server/6092/7)*