### PR TITLE
Fix potential JSON encoding issues

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -3,9 +3,9 @@
 {{- if and $index (gt $index 0) -}},{{- end }}
 {
 	"uri": "{{ $page.Permalink }}",
-	"title": "{{ htmlEscape $page.Title}}",
-	"tags": [{{ range $tindex, $tag := $page.Params.tags }}{{ if $tindex }}, {{ end }}"{{ $tag| htmlEscape }}"{{ end }}],
-	"description": "{{ htmlEscape .Description}}",
+	"title": {{ $page.Title | jsonify }},
+	"tags": {{ $page.Params.tags | jsonify }},
+	"description": {{ .Description | jsonify }},
 	"content": {{$page.Plain | jsonify}}
 }
 {{- end -}}


### PR DESCRIPTION
Previous HTML-escapsing was used.  But this would fail for different
special characters (e.g. single quotes).
Use "jsonify" for proper formatting instead.