### PR TITLE
Fix documentation and styling of site logo

### DIFF
--- a/exampleSite/content/configuration/_index.md
+++ b/exampleSite/content/configuration/_index.md
@@ -30,7 +30,7 @@ in the <code>config.toml</code> or the <code>frontmatter</code> (a page's markdo
 An optional site logo can be specified:
 
 {{< code >}}
-logo = /logo.svg
+site_logo = /logo.svg
 {{< /code >}}
 
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
         <div>
             <a class="navbar-brand" href="{{ .Site.BaseURL | relLangURL }}">
                 {{ with .Site.Params.site_logo }}
-                    <img src="{{ . }}" height="3rem" />
+                    <img src="{{ . }}" />
                 {{ end }}
                 {{ .Site.Title }}
             </a>


### PR DESCRIPTION
* the `Params` key is `site_logo` (not `logo`)
    * fixup for 9bf32e1c746404014bd23cd6521a2a5a2133216e
* allow override of logo height via CSS
