### PR TITLE
support for images/favicon.png

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,6 +17,9 @@
     {{ $style := resources.Get "css/ace.scss" | toCSS | minify }}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
 
+    {{ "<!--Favicon-->" | safeHTML }}
+    <link rel="icon" href="{{ `images/favicon.png` | absURL }}" type="image/x-icon">
+
     <!-- Only include the tracking when using `hugo` or adding `--environment production` -->
     {{ if eq hugo.Environment "production" }}
         {{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
support favicon.png. the proposed location is static/images/ though /static could be favoured, what do you think?
Does it need mention in the README.md?