### PR TITLE
fix RSS feed icon url

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,9 +29,10 @@
             </div>
         {{- end}}
     </div>
+    {{- $root := . }}
     {{ with .OutputFormats.Get "rss" -}}
         <div class="feed-icons">
-            <a href=".Permalink"><img src="/img/feed-icon.svg" alt="RSS feed" /></a>
+            <a href=".Permalink"><img src="{{ $root.Site.BaseURL }}img/feed-icon.svg" alt="RSS feed" /></a>
         </div>
     {{ end -}}
 </nav>


### PR DESCRIPTION
The RSS Icon did not use the base url which leads to issues if the site is not hosted on /