### PR TITLE
Fix RSS link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,7 +31,7 @@
     </div>
     {{ with .OutputFormats.Get "rss" -}}
         <div class="feed-icons">
-            <a href=".Permalink"><img src="/img/feed-icon.svg" alt="RSS feed" /></a>
+            <a href="{{ .Permalink }}"><img src="/img/feed-icon.svg" alt="RSS feed" /></a>
         </div>
     {{ end -}}
 </nav>


### PR DESCRIPTION
Fixes #39

The href value was not surrounded with double curly braces, so the `.Permalink` was not being expanded.