### PR TITLE
Add meta description tag if a page's description has a value

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Ace documentation"
-description = ""
+description = "Ace is a theme for Hugo, a fast static website generator written in Go, that allows you to easily write well organized and clean documentation for your projects."
 +++
 
 {{< lead >}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,9 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
+    {{ if ne .Description ""}}
+    <meta name="description" content="{{ .Description }}">
+    {{ end }}
     {{ range .AlternativeOutputFormats -}}
         {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}


### PR DESCRIPTION
We wanted to add the meta description tag for SEO. I opened this against master instead of dev, as the dev branch seems to be fairly out of date.