### PR TITLE
Add option to show fontawesome icons in the menu

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -39,7 +39,19 @@
         {{- if ne $numberOfPages 0 }} haschildren{{end}}
         ">
         <!-- I'm the params head -->
-        <a class="nav-link p-0" href="{{.RelPermalink}}"><h6>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</h6></a>
+        {{ if .Site.Params.enableIcons }}
+          <a class="nav-link p-0 justify-content-start align-items-baseline" href="{{.RelPermalink}}">
+            {{ if isset .Params "icon" }}
+              <i class="nav-link__icon mr-1 {{ .Params.icon | safeHTML}}"></i>
+            {{ else }}
+              <i class="nav-link__icon mr-1 fa fa-arrow-right"></i>
+            {{ end }}
+            <h6>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</h6>
+          </a>
+        {{ else }}
+          <a class="nav-link p-0" href="{{.RelPermalink}}"><h6>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</h6></a>
+        {{ end }}
+
       {{- if ne $numberOfPages 0 }}
         <ul class="list-unstyled ml-2">
           {{- .Scratch.Set "pages" .Pages }}
@@ -70,9 +82,20 @@
     {{- if not .Params.Hidden }}
         <li data-nav-id="{{.RelPermalink}}" class="nav-item my-1 {{- if eq .RelPermalink $currentNode.RelPermalink}} active{{end -}}">
                 <!-- I'm the params hidden -->
-                 <a href="{{.RelPermalink}}" class="nav-link p-0">
+                {{ if .Site.Params.enableIcons }}
+                  <a href="{{.RelPermalink}}" class="nav-link p-0 justify-content-start align-items-baseline">
+                    {{ if isset .Params "icon" }}
+                      <i class="nav-link__icon mr-1 {{ .Params.icon | safeHTML}}"></i>
+                    {{ else }}
+                      <i class="nav-link__icon mr-1 fa fa-arrow-right"></i>
+                    {{ end }}
                     {{safeHTML .Params.Pre}}{{.LinkTitle}}{{safeHTML .Params.Post}}
-                </a>
+                  </a>
+                {{ else }}
+                  <a href="{{.RelPermalink}}" class="nav-link p-0">
+                    {{safeHTML .Params.Pre}}{{.LinkTitle}}{{safeHTML .Params.Post}}
+                  </a>
+                {{ end }}
         </li>
     {{- end}}
 {{- end}}


### PR DESCRIPTION
## Description 

Adding the **option** to show fontawesome icons next to the links of the main menu. This works with a new parameter in the site's configuration.

This applies to main links and sub-links. Both links have the icon `fa fa-arrow-right` as the default one if nothing was specified in the `.md` file.

## How to use this feature

### Configuration
If you want to turn this on, you need to add this new parameter in the configuration file of your website (`config.toml`) and add `true` as its value.

```toml
[params]
enableIcons = true
```

### Adding icons

Now you can specify the icon in the front-matter of your `.md` file.

```md
+++
title = "Getting started"
description = ""
weight = 1
icon = "fas fa-fax"
+++
```

Note: You only need to add the name of the class, don't need to specify the HTML structure.

### Turning off this feature

You can disable this feature by removing the `enableIcons` parameter from the configuration, or changing its value to `false`.


## Images
![Screen Shot 2022-11-10 at 18 00 51](https://user-images.githubusercontent.com/19642693/201231185-6ad5e78b-1e55-4fe3-9061-2b36b4dbd481.png)

