### PR TITLE
Add option to always show menu expanded

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -41,7 +41,7 @@
         <!-- I'm the params head -->
         <a class="nav-link p-0" href="{{.RelPermalink}}"><h6>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</h6></a>
       {{- if ne $numberOfPages 0 }}
-        <ul class="list-unstyled ml-2">
+        <ul class="list-unstyled ml-2 {{- if .Site.Params.enableMenuExpanded }} d-block {{end -}}">
           {{- .Scratch.Set "pages" .Pages }}
           {{- if .Sections}}
           {{- .Scratch.Set "pages" (.Pages | union .Sections) }}


### PR DESCRIPTION
## Description

Based on what I saw in this issue: https://github.com/vantagedesign/ace-documentation/issues/13
This PR adds the option to always expand the menu and show the sub-links

## How to use this feature

### Configuration
If you want to turn this on, you need to add this new parameter in the configuration file of your website (`config.toml`) and add `true` as its value.

```toml
[params]
enableMenuExpanded = true
```

### Turning off this feature

You can disable this feature by removing the `enableMenuExpanded ` parameter from the configuration, or changing its value to `false`.


## Images

### Item active with sub-links
![Screen Shot 2022-11-11 at 16 14 07](https://user-images.githubusercontent.com/19642693/201438645-3e98ccae-c64a-4a4e-bcd1-376a811814a3.png)

### Item active without sub-links
![Screen Shot 2022-11-11 at 16 14 37](https://user-images.githubusercontent.com/19642693/201438651-644d1922-4c88-47cc-9d60-4ca5be624963.png)
