### PR TITLE
Enable to apply LanguageCode to `lang` attribute of `<html>` element

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html{{ with site.LanguageCode | default site.Language.Lang }} lang="{{ . }}"{{ end }}>
     {{- partial "head.html" . -}}
     <body>
 


### PR DESCRIPTION
In this change, we are able to use `LanguageCode` in the `config.toml` to `lang` attribute of the `<html>` element. 
`lang` attribute has an important role in the behavior of screen readers in web accessibility ([details](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html#accessibility_concerns)).

ref.

- https://gohugo.io/getting-started/configuration/#languagecode
- https://github.com/gohugoio/hugo/blob/90da7664bf1f3a0ca2e18144b5deacf532c6e3cf/tpl/tplimpl/embedded/templates/alias.html#L2