### PR TITLE
Fix javascript resources urls

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,8 @@
 <!-- Load required Javascript -->
-<script src="{{ .Site.BaseURL }}lib/jquery.min.js"></script> <!-- jQuery.js -->
-<script src="{{ .Site.BaseURL }}lib/popper.min.js"></script> <!-- Popper.js - dependency of Bootstrap -->
+<script src="{{ "lib/jquery.min.js" | relURL }}"></script> <!-- jQuery.js -->
+<script src="{{ "lib/popper.min.js" | relURL }}"></script> <!-- Popper.js - dependency of Bootstrap -->
 
-<script src="{{ .Site.BaseURL }}js/bootstrap.min.js"></script> <!-- Other javascript -->
+<script src="{{ "js/bootstrap.min.js" | relURL }}"></script> <!-- Other javascript -->
 
 <!-- Plugin: search -->
 <script type="text/javascript" src="{{"plugins/lunr.min.js" | relURL}}"></script>


### PR DESCRIPTION
Base URLS don't always end with a `/`, preventing some resources to load correctly.  
This change builds URLs correctly.