### PR TITLE
Fix for deprecated "google_analytics_async.html" template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,7 +28,7 @@
 
     <!-- Only include the tracking when using `hugo` or adding `--environment production` -->
     {{ if eq hugo.Environment "production" }}
-        {{ template "_internal/google_analytics_async.html" . }}
+        {{ template "_internal/google_analytics.html" . }}
     {{ end }}
 
 </head>


### PR DESCRIPTION
Fix for issue described here https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410 - template deprecated and now removed in latest versions of hugo.